### PR TITLE
chore(form/product): add ad relevance input hidden

### DIFF
--- a/src/controllers/resources/form/products.js
+++ b/src/controllers/resources/form/products.js
@@ -2135,5 +2135,10 @@ export default function () {
     setTimeout(() => {
       listOrders(tabId)
     }, 1500)
+    document.getElementById(`t${tabId}-ad-relevance-link`).addEventListener('click', ($el) => {
+      $el.currentTarget.classList.add('d-none')
+      document.getElementById(`t${tabId}-ad-relevance`).classList.remove('d-none')
+
+    })
   }
 }

--- a/src/controllers/resources/form/products.js
+++ b/src/controllers/resources/form/products.js
@@ -2135,10 +2135,8 @@ export default function () {
     setTimeout(() => {
       listOrders(tabId)
     }, 1500)
-    document.getElementById(`t${tabId}-ad-relevance-link`).addEventListener('click', ($el) => {
-      $el.currentTarget.classList.add('d-none')
+    document.getElementById(`t${tabId}-ad-relevance-link`).addEventListener('click', () => {
       document.getElementById(`t${tabId}-ad-relevance`).classList.remove('d-none')
-
     })
   }
 }

--- a/src/controllers/resources/form/products.js
+++ b/src/controllers/resources/form/products.js
@@ -2137,6 +2137,6 @@ export default function () {
     }, 1500)
     document.getElementById(`t${tabId}-ad-relevance-link`).addEventListener('click', () => {
       $(`t${tabId}-ad-relevance`).slideToggle()
-    })
+    }, false)
   }
 }

--- a/src/controllers/resources/form/products.js
+++ b/src/controllers/resources/form/products.js
@@ -2136,7 +2136,7 @@ export default function () {
       listOrders(tabId)
     }, 1500)
     document.getElementById(`t${tabId}-ad-relevance-link`).addEventListener('click', () => {
-      document.getElementById(`t${tabId}-ad-relevance`).classList.remove('d-none')
+      $(`t${tabId}-ad-relevance`).slideToggle()
     })
   }
 }

--- a/src/views/resources/form/products.html
+++ b/src/views/resources/form/products.html
@@ -611,7 +611,7 @@
               <span data-lang="en_us">Config search relevance</span>
               <span data-lang="pt_br">Configurar relevância na busca</span>
             </a>
-            <div class="form-group d-none" data-id="ad-relevance">
+            <div class="form-group" style="display: none" data-id="ad-relevance">
               <input type="number" class="form-control w-160px" name="ad_relevance" />
               <span class="i18n">
                 <small data-lang="en_us">Products with greater relevance appear earlier in search results</small>

--- a/src/views/resources/form/products.html
+++ b/src/views/resources/form/products.html
@@ -578,17 +578,6 @@
                 </small>
               </span>
             </div>
-            <a class="i18n" href="javascript:;" onclick="document.getElementById('ad_relevance').classList.remove('d-none');this.classList.add('d-none')">
-              <span data-lang="en_us">Config search relevance</span>
-              <span data-lang="pt_br">Configurar relevância na busca</span>
-            </a>
-            <div class="form-group d-none" id="ad_relevance">
-              <input type="number" class="form-control w-160px" name="ad_relevance" />
-              <span class="i18n">
-                <small data-lang="en_us">Products with greater relevance appear earlier in search results</small>
-                <small data-lang="pt_br">Produtos com maior relevância aparecem antes nos resultados de busca</small>
-              </span>
-            </div>
             <div class="row">
               <div class="col-sm-5 col-md-12 col-lg-5">
                 <div class="form-group">
@@ -617,6 +606,17 @@
                   </select>
                 </div>
               </div>
+            </div>
+            <a class="i18n" href="javascript:;" data-id="ad-relevance-link">
+              <span data-lang="en_us">Config search relevance</span>
+              <span data-lang="pt_br">Configurar relevância na busca</span>
+            </a>
+            <div class="form-group d-none" data-id="ad-relevance">
+              <input type="number" class="form-control w-160px" name="ad_relevance" />
+              <span class="i18n">
+                <small data-lang="en_us">Products with greater relevance appear earlier in search results</small>
+                <small data-lang="pt_br">Produtos com maior relevância aparecem antes nos resultados de busca</small>
+              </span>
             </div>
           </div>
         </div>

--- a/src/views/resources/form/products.html
+++ b/src/views/resources/form/products.html
@@ -592,6 +592,21 @@
                     data-json="true">
                   </select>
                 </div>
+                <a class="i18n" href="javascript:;" onclick="document.getElementById('ad_relevance').classList.remove('d-none');this.classList.add('d-none')">
+                  <span data-lang="en_us">Config relevance</span>
+                  <span data-lang="pt_br">Configurar relevância</span>
+                </a>
+                <div class="form-group d-none" id="ad_relevance">
+                  <label class="i18n">
+                    <span data-lang="en_us">Search relevance</span>
+                    <span data-lang="pt_br">Relevância na busca</span>
+                  </label>
+                  <input type="number" class="form-control" name="ad_relevance" />
+                  <span class="i18n">
+                    <small data-lang="en_us">Higher number, more relevant in the search</small>
+                    <small data-lang="pt_br">Quanto maior número, mais relevante na busca</small>
+                  </span>
+                </div>
               </div>
               <div class="col-sm-7 col-md-12 col-lg-7">
                 <div class="form-group">
@@ -607,17 +622,6 @@
                   </select>
                 </div>
               </div>
-            </div>
-            <a class="i18n" href="javascript:;" onclick="document.getElementById('ad_relevance').classList.remove('d-none');this.classList.add('d-none')">
-              <span data-lang="en_us">Config search relevance</span>
-              <span data-lang="pt_br">Configurar relevância na busca</span>
-            </a>
-            <div class="form-group d-none" id="ad_relevance">
-              <label class="i18n">
-                <span data-lang="en_us">Search relevance</span>
-                <span data-lang="pt_br">Relevância na busca</span>
-              </label>
-              <input type="number" class="form-control" name="ad_relevance" />
             </div>
           </div>
         </div>

--- a/src/views/resources/form/products.html
+++ b/src/views/resources/form/products.html
@@ -578,7 +578,17 @@
                 </small>
               </span>
             </div>
-
+            <a class="i18n" href="javascript:;" onclick="document.getElementById('ad_relevance').classList.remove('d-none');this.classList.add('d-none')">
+              <span data-lang="en_us">Config search relevance</span>
+              <span data-lang="pt_br">Configurar relevância na busca</span>
+            </a>
+            <div class="form-group d-none" id="ad_relevance">
+              <input type="number" class="form-control w-160px" name="ad_relevance" />
+              <span class="i18n">
+                <small data-lang="en_us">Products with greater relevance appear earlier in search results</small>
+                <small data-lang="pt_br">Produtos com maior relevância aparecem antes nos resultados de busca</small>
+              </span>
+            </div>
             <div class="row">
               <div class="col-sm-5 col-md-12 col-lg-5">
                 <div class="form-group">
@@ -591,21 +601,6 @@
                     data-properties="_id,name,slug,logo"
                     data-json="true">
                   </select>
-                </div>
-                <a class="i18n" href="javascript:;" onclick="document.getElementById('ad_relevance').classList.remove('d-none');this.classList.add('d-none')">
-                  <span data-lang="en_us">Config relevance</span>
-                  <span data-lang="pt_br">Configurar relevância</span>
-                </a>
-                <div class="form-group d-none" id="ad_relevance">
-                  <label class="i18n">
-                    <span data-lang="en_us">Search relevance</span>
-                    <span data-lang="pt_br">Relevância na busca</span>
-                  </label>
-                  <input type="number" class="form-control" name="ad_relevance" />
-                  <span class="i18n">
-                    <small data-lang="en_us">Higher number, more relevant in the search</small>
-                    <small data-lang="pt_br">Quanto maior número, mais relevante na busca</small>
-                  </span>
                 </div>
               </div>
               <div class="col-sm-7 col-md-12 col-lg-7">

--- a/src/views/resources/form/products.html
+++ b/src/views/resources/form/products.html
@@ -608,6 +608,17 @@
                 </div>
               </div>
             </div>
+            <a class="i18n" href="javascript:;" onclick="document.getElementById('ad_relevance').classList.remove('d-none');this.classList.add('d-none')">
+              <span data-lang="en_us">Config search relevance</span>
+              <span data-lang="pt_br">Configurar relevância na busca</span>
+            </a>
+            <div class="form-group d-none" id="ad_relevance">
+              <label class="i18n">
+                <span data-lang="en_us">Search relevance</span>
+                <span data-lang="pt_br">Relevância na busca</span>
+              </label>
+              <input type="number" class="form-control" name="ad_relevance" />
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Como em outras vezes, não foi possível inserir a configuração para não atrapalhar a view atual, em uma determinada vez sugeriu manter ela escondida:

![Screenshot 2023-04-04 at 16-30-42 E-Com Plus Dashboard App](https://user-images.githubusercontent.com/35343551/229910528-b9da9641-68aa-445e-a72b-1895a12de645.png)

Após clicar:

![Screenshot 2023-04-04 at 16-31-00 E-Com Plus Dashboard App](https://user-images.githubusercontent.com/35343551/229910533-cf68b003-a82c-49ee-81fb-f04eb753c993.png)
