### PR TITLE
chore(resource): insert choice checkbox to import with PUT instead of PATCH

### DIFF
--- a/src/controllers/resources.js
+++ b/src/controllers/resources.js
@@ -706,6 +706,8 @@ export default function () {
           $(`#t${tabId}-loading`).show()
           const cb = Tab.editItemsCallback()
           const file = $modal.find('input[type="file"]')[0].files[0]
+          const isPut = $modal.find('#method-put').is(':checked')
+          const importMethod = isPut ? 'PUT' : 'PATCH'
           Papa.parse(file, {
             header: true,
             error: (err, file, inputElem, reason) => {
@@ -777,7 +779,7 @@ export default function () {
 
                 if (_id && _id.length > 2) {
                   if (/^[a-f0-9]{24}$/.test(_id)) {
-                    callApi(`${slug}/${_id}.json`, 'PATCH', (err, doc) => {
+                    callApi(`${slug}/${_id}.json`, importMethod, (err, doc) => {
                       if (err) {
                         console.error(err)
                         app.toast()

--- a/src/controllers/resources.js
+++ b/src/controllers/resources.js
@@ -698,14 +698,6 @@ export default function () {
       })
 
       // import CSV table
-      $('#method-put').change((e) => {
-        if ($('#method-put').is(':checked')) {
-          window.alert(i18n({
-            en_us: 'Will delete properties that are not in the table and change the ones that are',
-            pt_br: 'Irá deletar propriedades que não estão na tabela e mudar as que estiverem'
-          }))
-        } 
-      })
       $(`#t${tabId}-import`).click(function () {
         const $modal = $('#table-upload')
         $modal.modal('toggle')

--- a/src/controllers/resources.js
+++ b/src/controllers/resources.js
@@ -698,6 +698,14 @@ export default function () {
       })
 
       // import CSV table
+      $('#method-put').change((e) => {
+        if ($('#method-put').is(':checked')) {
+          window.alert(i18n({
+            en_us: 'Will delete properties that are not in the table and change the ones that are',
+            pt_br: 'Irá deletar propriedades que não estão na tabela e mudar as que estiverem'
+          }))
+        } 
+      })
       $(`#t${tabId}-import`).click(function () {
         const $modal = $('#table-upload')
         $modal.modal('toggle')

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -806,10 +806,10 @@
                 <input type="file" accept=".csv">
               </div>
               <div class="custom-control custom-control-danger custom-checkbox">
-                <input type="checkbox" class="custom-control-input" data-id="method-put">
+                <input type="checkbox" class="custom-control-input" id="method-put">
                 <label class="custom-control-label i18n" for="method-put">
-                  <span style="color: var(--danger)" data-lang="en_us">Overwrite <small style="color: var(--danger)">(Will delete properties that are not in the table and change the ones that are)</small></span>
-                  <span style="color: var(--danger)" data-lang="pt_br">Sobrescrever <small style="color: var(--danger)">(Irá deletar propriedades que não estão na tabela e mudar as que estiverem)</small></span>
+                  <span class="text-danger" data-lang="en_us">Overwrite</span>
+                  <span class="text-danger" data-lang="pt_br">Sobrescrever</span>
                 </label>
               </div>
             </div>

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -810,8 +810,15 @@
                 <label class="custom-control-label i18n" for="method-put">
                   <span class="text-danger" data-lang="en_us">Overwrite</span>
                   <span class="text-danger" data-lang="pt_br">Sobrescrever</span>
-                </label>
+                </label>               
               </div>
+              <div id="overwrite-alert" class="alert alert-danger i18n alert-dismissible fade show" role="alert">
+                <span data-lang="en_us">If active <b>overwrite</b>, will delete properties that are not in the table and change the ones that are</span>
+                <span data-lang="pt_br">Se <b>sobrescrever</b> ativo, irá deletar propriedades que não estão na tabela e mudar as que estiverem</span>
+                <button type="button" class="close d-block" data-dismiss="alert" aria-label="Close">
+                  <span aria-hidden="true">&times;</span>
+                </button>              
+              </div> 
             </div>
           </div>
           <div class="modal-footer">

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -812,7 +812,7 @@
                   <span class="text-danger" data-lang="pt_br">Sobrescrever</span>
                 </label>               
               </div>
-              <div id="overwrite-alert" class="alert alert-danger i18n alert-dismissible fade show" role="alert">
+              <div id="overwrite-alert" class="alert alert-warning mt-1 i18n alert-dismissible fade show" role="alert">
                 <span data-lang="en_us">If active will delete properties that are not in the table and change the ones that are</span>
                 <span data-lang="pt_br">Se ativo irá deletar propriedades que não estão na tabela e mudar as que estiverem</span>
                 <button type="button" class="close d-block" data-dismiss="alert" aria-label="Close">

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -806,7 +806,7 @@
                 <input type="file" accept=".csv">
               </div>
               <div class="custom-control custom-control-danger custom-checkbox">
-                <input type="checkbox" class="custom-control-input" id="method-put">
+                <input type="checkbox" class="custom-control-input" data-id="method-put">
                 <label class="custom-control-label i18n" for="method-put">
                   <span style="color: var(--danger)" data-lang="en_us">Overwrite <small style="color: var(--danger)">(Will delete properties that are not in the table and change the ones that are)</small></span>
                   <span style="color: var(--danger)" data-lang="pt_br">Sobrescrever <small style="color: var(--danger)">(Irá deletar propriedades que não estão na tabela e mudar as que estiverem)</small></span>

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -805,6 +805,13 @@
                 <input type="text" class="form-control file-value file-browser" placeholder="Upload" readonly="">
                 <input type="file" accept=".csv">
               </div>
+              <div class="custom-control custom-control-danger custom-checkbox">
+                <input type="checkbox" class="custom-control-input" id="method-put">
+                <label class="custom-control-label i18n" for="method-put">
+                  <span style="color: var(--danger)" data-lang="en_us">Overwrite <small style="color: var(--danger)">(Will delete properties that are not in the table and change the ones that are)</small></span>
+                  <span style="color: var(--danger)" data-lang="pt_br">Sobrescrever <small style="color: var(--danger)">(Irá deletar propriedades que não estão na tabela e mudar as que estiverem)</small></span>
+                </label>
+              </div>
             </div>
           </div>
           <div class="modal-footer">

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -813,8 +813,8 @@
                 </label>               
               </div>
               <div id="overwrite-alert" class="alert alert-danger i18n alert-dismissible fade show" role="alert">
-                <span data-lang="en_us">If active <b>overwrite</b>, will delete properties that are not in the table and change the ones that are</span>
-                <span data-lang="pt_br">Se <b>sobrescrever</b> ativo, irá deletar propriedades que não estão na tabela e mudar as que estiverem</span>
+                <span data-lang="en_us">If active will delete properties that are not in the table and change the ones that are</span>
+                <span data-lang="pt_br">Se ativo irá deletar propriedades que não estão na tabela e mudar as que estiverem</span>
                 <button type="button" class="close d-block" data-dismiss="alert" aria-label="Close">
                   <span aria-hidden="true">&times;</span>
                 </button>              


### PR DESCRIPTION
Padrão:
![image](https://user-images.githubusercontent.com/35343551/231256306-776e20bd-7cb6-40dc-b112-c01f3d4bcdf4.png)

Com check:
![image](https://user-images.githubusercontent.com/35343551/231254530-6aa4c9aa-6d1b-4040-b7bb-d97dd9decaf4.png)
Alguns lojistas sempre perguntam, como apagar determinada coisa via tabela, pelo PATCH, se não tem, não edita, isso acontece muito com variações. Mas em contrapartida, pessoal gosta muito também que dá pra editar só o que estiver na tabela, facilita muito nas edições por tabela. Por isso, pensei em incluir essa opção, por padrão não é, se clicar, ai vai sobrescrever. 
Mas isso também, as vezes pode atrapalhar, a pessoa clicar sem ler, acontece um pouco, coloquei de vermelho pra ver se a pessoa tente ver.

Se não for uma boa opção, ai talvez eu possa apenas colocar lá, se tiver variations e o lojista colocar uma prop false, eu coloco um variations: [] que removeria as variações. Veja o que acha e depois me fale.