### PR TITLE
fix(products): slide toggle id tab relevance

### DIFF
--- a/src/controllers/resources/form/products.js
+++ b/src/controllers/resources/form/products.js
@@ -2136,7 +2136,7 @@ export default function () {
       listOrders(tabId)
     }, 1500)
     document.getElementById(`t${tabId}-ad-relevance-link`).addEventListener('click', () => {
-      $(`t${tabId}-ad-relevance`).slideToggle()
+      $(`#t${tabId}-ad-relevance`).slideToggle()
     }, false)
   }
 }


### PR DESCRIPTION
Acabou que quando mudou para slideToggle, ficou sem o # para id, então não rolava o slideToggle