### PR TITLE
chore(form): add font size option

### DIFF
--- a/src/controllers/resources/form.js
+++ b/src/controllers/resources/form.js
@@ -419,6 +419,7 @@ export default function () {
             toolbar: [
               [ 'style', [ 'style' ] ],
               [ 'font', [ 'bold', 'italic', 'underline', 'strikethrough', 'clear' ] ],
+              ['fontsize', ['fontsize']],
               [ 'color', [ 'color' ] ],
               [ 'insert', [ 'picture', 'link', 'video', 'hr', 'table' ] ],
               [ 'paragraph', [ 'ul', 'ol', 'paragraph' ] ],


### PR DESCRIPTION
![image](https://github.com/ecomplus/admin/assets/35343551/11a0fe5c-d90e-46ec-bb69-4450125da15f)
Some clients were using heading tags to change size of text. So the correct is font size option